### PR TITLE
KAIZEN-0 bruk query param for oppfolgingsstatus mot veilarboppfolging

### DIFF
--- a/src/main/java/no/nav/fo/veilarbtiltakinfo/oppfolging/OppfolgingClient.java
+++ b/src/main/java/no/nav/fo/veilarbtiltakinfo/oppfolging/OppfolgingClient.java
@@ -27,7 +27,7 @@ public class OppfolgingClient {
 
     public Oppfolgingsstatus oppfolgingsstatus(String fnr) {
         Oppfolgingsstatus oppfolgingsstatus = RestUtils.withClient(
-            c -> c.target(veilarboppfolgingTarget + "/person/" + fnr + "/oppfolgingsstatus"
+            c -> c.target(veilarboppfolgingTarget + "/person/" + fnr + "/oppfolgingsstatus?brukArena=true"
             )
                 .request()
                 .header(COOKIE, AZUREADB2C_OIDC_COOKIE_NAME + "=" + SubjectHandler.getSsoToken(OIDC).orElseThrow(IllegalArgumentException::new))


### PR DESCRIPTION
For å få oppdatert data direkte fra arena og ikke via veilarbarena som har litt forsinkelse.